### PR TITLE
Add roscpp dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,13 +2,13 @@ cmake_minimum_required(VERSION 2.8)
 project(octomap_ros)
 set(CMAKE_CXX_STANDARD 11)
 
-find_package(catkin REQUIRED COMPONENTS octomap_msgs sensor_msgs tf)
+find_package(catkin REQUIRED COMPONENTS octomap_msgs roscpp sensor_msgs tf)
 find_package(OCTOMAP REQUIRED)
 
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS octomap_msgs sensor_msgs tf
+  CATKIN_DEPENDS octomap_msgs roscpp sensor_msgs tf
   DEPENDS OCTOMAP)
 
 include_directories(include ${catkin_INCLUDE_DIRS})

--- a/package.xml
+++ b/package.xml
@@ -16,11 +16,13 @@
 
   <build_depend>octomap_msgs</build_depend>
   <build_depend>octomap</build_depend>
+  <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>tf</build_depend>
 
   <run_depend>octomap_msgs</run_depend>
   <run_depend>octomap</run_depend>
+  <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>tf</run_depend>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -4,16 +4,16 @@
   <description>
     octomap_ros provides conversion functions between ROS and OctoMap's native types.
     This enables a convenvient use of the octomap package in ROS.
-    
+
   </description>
   <author email="armin@hornung.io">Armin Hornung</author>
   <maintainer email="armin@hornung.io">Armin Hornung</maintainer>
   <license>BSD</license>
   <url type="website">http://ros.org/wiki/octomap_ros</url>
   <url type="bugtracker">https://github.com/OctoMap/octomap_ros/issues</url>
-  
+
   <buildtool_depend>catkin</buildtool_depend>
-  
+
   <build_depend>octomap_msgs</build_depend>
   <build_depend>octomap</build_depend>
   <build_depend>sensor_msgs</build_depend>


### PR DESCRIPTION
Sometimes our snap builds fail because this package, or one of its
dependencies, needs roscpp built before it. Most of the time roscpp
gets builts before octomap_ros, but there is nothing to guarantee it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/octomap_ros/1)
<!-- Reviewable:end -->
